### PR TITLE
add caller function name to logline

### DIFF
--- a/utils/log.go
+++ b/utils/log.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/banzaicloud/banzai-types/configuration"
+	"runtime"
+	"strings"
 )
 
 var log *logrus.Logger
@@ -58,8 +60,23 @@ func SetLogLevel(level string) {
 	log.SetLevel(l)
 }
 
+func getFunctionName() string {
+	pc := make([]uintptr, 1)
+	n := runtime.Callers(4, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	f, _ := frames.Next()
+	fullName := strings.Split(f.Function, "/")
+	var functionName string
+	if ln := len(fullName); ln >= 2 {
+		functionName = fullName[ln - 2] + "/" + fullName[ln - 1]
+	} else {
+		functionName = fullName[0]
+	}
+	return "(" + functionName + ")"
+}
+
 func getTag(tag string) string {
-	return " ### [" + tag + "] ### "
+	return getFunctionName() + " ### [" + tag + "] ### "
 }
 
 func prepareFormat(tag string, format string) string {


### PR DESCRIPTION
I thought would be useful to add function names automatically to log lines.

May be it would be useful instead of tags, or near using tags to have function where we can pass  gin.Context to display the requestURI.

  func LogInfor(c *gin.Context, args ... interface{}) {
  	log.Info(getTag(c.Request.RequestURI), getMessage(args))
  }


